### PR TITLE
fixed magic header reading

### DIFF
--- a/mds2iso.c
+++ b/mds2iso.c
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
 
 	struct mds_s mds;
 	memcpy(&mds, mds_file.data, sizeof(mds));
-	if (!memcmp(mds.magic, "MEDIA_DESCRIPTOR", sizeof(mds.magic)))
+	if (memcmp(mds.magic, "MEDIA_DESCRIPTOR", sizeof(mds.magic))) // CAN YOU SEE IT NOW, BITCH? -darkmage
 		errx(1, "not an mds file? bad magic in '%s'", infilename);
 	mds_ntoh(&mds);
 


### PR DESCRIPTION
Taken from the `man` pages for `memcmp`:

```
memcmp(3)                                             Library Functions Manual                                             memcmp(3)

NAME
       memcmp - compare memory areas

LIBRARY
       Standard C library (libc, -lc)

SYNOPSIS
       #include <string.h>

       int memcmp(const void s1[.n], const void s2[.n], size_t n);

DESCRIPTION
       The memcmp() function compares the first n bytes (each interpreted as unsigned char) of the memory areas s1 and s2.

RETURN VALUE
       The  memcmp()  function returns an integer less than, equal to, or greater than zero if the first n bytes of s1 is found, re‐
       spectively, to be less than, to match, or be greater than the first n bytes of s2.

       For a nonzero return value, the sign is determined by the sign of the difference between the first pair of bytes (interpreted
       as unsigned char) that differ in s1 and s2.

       If n is zero, the return value is zero.

ATTRIBUTES
       For an explanation of the terms used in this section, see attributes(7).

```


This commit corrects the error in logic made by the programmer. Programmer assumed `memcmp` returning 0 meant failure. The code may have been written for a platform with a different `memcmp` implementation and if so will need platform-specific handling for cases when `memcmp` would return a non-zero value for equal values.